### PR TITLE
fix(oop): assign the return value to the method name in Capacity

### DIFF
--- a/06_oop_in_st/exercises/4_inheritance_complex_valve/src/TankWithVolume.st
+++ b/06_oop_in_st/exercises/4_inheritance_complex_valve/src/TankWithVolume.st
@@ -21,6 +21,7 @@ NAMESPACE FluidHandlingClass
                 currentVolume : REAL;
             END_VAR 
             _capacity := (currentVolume / volume) * 100;
+            Capacity := _capacity;
         END_METHOD
 
         METHOD PUBLIC OpenInlet 

--- a/06_oop_in_st/exercises/solution/src/TankWithVolume.st
+++ b/06_oop_in_st/exercises/solution/src/TankWithVolume.st
@@ -19,6 +19,7 @@ NAMESPACE FluidHandlingInterfaces
                 currentVolume : REAL;
             END_VAR 
             _capacity := (currentVolume / volume) * 100;
+            Capacity := _capacity;
         END_METHOD
 
         METHOD PUBLIC OpenInlet 


### PR DESCRIPTION
Fixes #38.

`Capacity` computes the percentage into the protected `_capacity` member and stops there. In ST a method returns by assigning to its own name, so it hands back `0`.

That return value is read:

```
src/program.st:41   capacity_percentage := tank.Capacity(currentVolume := current_volume);
src/program.st:85   capacity_percentage := tank.Capacity(currentVolume := current_volume);
src/program.st:109  capacity_percentage := tank.Capacity(currentVolume := current_volume);
```

and the exercise text asks for:

> **Capacity : REAL** that returns a real with the percentage of capacity of the volume of the tank.

So `capacity_percentage` stays at zero for anyone following the module, which is a confusing thing to meet while learning the language.

The member assignment is kept and the return added on top, which is the shape `GetState` already uses in `ValveBase.st`:

```
GetState := ValveState#Open;
...
_state := GetState;
```

Applied in both copies — `exercises/solution/` and `exercises/4_inheritance_complex_valve/`.

**Two things I looked at and left alone**

`0_basic_valve_class/src/ValveBase.st` also has a `GetState` that does not assign to its name, but every method there is `;` — it is the skeleton the exercise asks the reader to fill in, so it is correct as it stands.

`TankWithShape.st` has two `VolumeCalculator : REAL` methods which assign to `volume` rather than to the method name. Here I was not sure what you intend: the slides say the volume is "calculated with a method called *VolumeCalculator* and the result stored in the property *volume*", and the only caller ignores the return value:

```
CalculatorWithRegulation.st:42   tankCube.VolumeCalculator();
```

So the body matches the brief and nothing is broken — but then the `: REAL` return type is never used, which is its own small trap for a reader learning how ST methods return. Either adding `VolumeCalculator := volume;` or dropping the return type would settle it. Happy to do whichever you prefer, in this PR or a separate one.

**On verification**

I have no AX toolchain here, so I did not compile this. What I checked is that the change follows the assignment form already used elsewhere in the module, that the callers listed above do read the value, and that nothing else in module 6 has the same shape — I walked every `METHOD ... : <type>` in the module and the only remaining ones are the two described above.
